### PR TITLE
Use D3 for creating the .multiformList DOM elements (re-use if possible)

### DIFF
--- a/src/column/AColumn.ts
+++ b/src/column/AColumn.ts
@@ -41,13 +41,21 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
   dataView: IDataType;
   sortCriteria: string = SORT.asc;
   rangeView: Range;
-  multiformList: TaggleMultiform[] = [];
 
   selectedAggVis: IVisPluginDesc;
   selectedUnaggVis: IVisPluginDesc;
 
+  protected multiformMap: Map<string, TaggleMultiform> = new Map<string, TaggleMultiform>();
+
   constructor(public readonly data: DATATYPE, public readonly orientation: EOrientation) {
     super();
+  }
+
+  get multiformList():TaggleMultiform[] {
+    // return the array in the correct order of DOM elements
+    return this.body.selectAll('.multiformList')[0].map((d) => {
+      return this.multiformMap.get(d3.select(d).datum().key);
+    });
   }
 
   get idtype() {
@@ -137,7 +145,7 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
     this.appendVisChooser($toolbar, 'fa fa-ellipsis-v fa-fw', 'Select visualization for unaggregated areas', EAggregationType.UNAGGREGATED);
     this.appendVisChooser($toolbar, 'fa fa-window-minimize fa-fw fa-rotate-90', 'Select visualization for aggregated areas', EAggregationType.AGGREGATED);
 
-    $toolbar.append('div').classed('axis', true).append('svg').classed('taggle-axis', true);
+    $toolbar.append('div').classed('axis', true).append('svg').classed('taggle-axis', true).attr('style', 'width:100%;height:20px;');
   }
 
   private addIconVisChooser(toolbar: HTMLElement, visses: IVisPluginDesc[], aggregationType: EAggregationType) {

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -16,6 +16,7 @@ import {EAggregationType} from './VisManager';
 import {on, fire} from 'phovea_core/src/event';
 import {IHistogram} from 'phovea_core/src/math';
 import {AVectorFilter} from '../filter/AVectorFilter';
+import {VectorView} from '../../../phovea_core/src/vector/AVector';
 export declare type IStringVector = IVector<string, IStringValueTypeDesc>;
 
 export interface ITaggleHistogramData {
@@ -30,15 +31,12 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
 
   multiform: MultiForm;
   dataView: IDataType;
-  multiformList: TaggleMultiform[] = [];
   private $sortButton;
 
   constructor(data: DATATYPE, orientation: EOrientation) {
     super(data, orientation);
     this.dataView = data;
     this.rangeView = (<any>data).indices;
-
-
   }
 
   protected multiFormParams($body: d3.Selection<any>, histogramData?: ITaggleHistogramData): IMultiFormOptions {
@@ -93,6 +91,7 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
 
 
   async updateMultiForms(multiformRanges: Range[], stratifiedRanges?: Range[], brushedRanges?: Range[]) {
+    const that = this;
     const data: any = await this.data.data(); // wait first for data and then continue with removing old  forms
     const histData: IHistogram = await this.data.hist();
     let histogramData;
@@ -109,28 +108,46 @@ export abstract class AVectorColumn<T, DATATYPE extends IVector<T, any>> extends
     const viewPromises = multiformRanges.map((r) => this.data.idView(r));
 
     return Promise.all(viewPromises).then((views) => {
-
-      this.body.selectAll('.multiformList').remove();
-      this.multiformList = [];
-
-      views.forEach((view, id) => {
-        const $multiformDivs = this.body.append('div').classed('multiformList', true);
-
-        const m = new TaggleMultiform(view, <HTMLElement>$multiformDivs.node(), this.multiFormParams($multiformDivs, histogramData));
-        m.groupId = this.findGroupId(stratifiedRanges, multiformRanges[id]);
-        m.brushed = this.checkBrushed(brushedRanges, multiformRanges[id]);
-
-        //assign visses
-        if (this.selectedAggVis) {
-          VisManager.userSelectedAggregatedVisses.set(m.id, this.selectedAggVis);
-        }
-        if (this.selectedUnaggVis) {
-          VisManager.userSelectedUnaggregatedVisses.set(m.id, this.selectedUnaggVis);
-        }
-        VisManager.multiformAggregationType.set(m.id, EAggregationType.UNAGGREGATED);
-
-        this.multiformList.push(m);
+      const viewData = views.map((d:any) => {
+        return {
+          key: d.range.toString(),
+          view: d,
+        };
       });
+
+      const multiformList = this.body.selectAll('.multiformList').data(viewData, (d) => d.key);
+
+      multiformList.enter().append('div')
+        .classed('multiformList', true)
+        .each(function(d) {
+          const $elem = d3.select(this);
+          const m = new TaggleMultiform(d.view, <HTMLElement>$elem.node(), that.multiFormParams($elem, histogramData));
+          that.multiformMap.set(d.key, m);
+        });
+
+      multiformList
+        .each(function(d, i) {
+          const m = that.multiformMap.get(d.key);
+          m.groupId = that.findGroupId(stratifiedRanges, multiformRanges[i]);
+          m.brushed = that.checkBrushed(brushedRanges, multiformRanges[i]);
+
+          //assign visses
+          if (that.selectedAggVis) {
+            VisManager.userSelectedAggregatedVisses.set(m.id, that.selectedAggVis);
+          }
+          if (that.selectedUnaggVis) {
+            VisManager.userSelectedUnaggregatedVisses.set(m.id, that.selectedUnaggVis);
+          }
+          VisManager.multiformAggregationType.set(m.id, EAggregationType.UNAGGREGATED);
+      });
+
+      multiformList.exit().remove()
+        .each(function(d) {
+          that.multiformMap.delete(d.key);
+        });
+
+      // order DOM elements according to the data order
+      multiformList.order();
 
       return this.multiformList;
     });

--- a/src/column/AVectorColumn.ts
+++ b/src/column/AVectorColumn.ts
@@ -13,10 +13,8 @@ import MultiForm from 'phovea_core/src/multiform/MultiForm';
 import TaggleMultiform from './TaggleMultiform';
 import VisManager from './VisManager';
 import {EAggregationType} from './VisManager';
-import {on, fire} from 'phovea_core/src/event';
 import {IHistogram} from 'phovea_core/src/math';
 import {AVectorFilter} from '../filter/AVectorFilter';
-import {VectorView} from '../../../phovea_core/src/vector/AVector';
 export declare type IStringVector = IVector<string, IStringValueTypeDesc>;
 
 export interface ITaggleHistogramData {

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -114,9 +114,9 @@ export default class ColumnManager extends EventHandler {
     on(List.EVENT_BRUSH_CLEAR, this.clearBrush.bind(this));
     on(AFilter.EVENT_REMOVE_ME, this.remove.bind(this));
 
-    this.aggSwitcherCol.on(AggSwitcherColumn.EVENT_GROUP_AGG_CHANGED, (evt: any, index: number, value: EAggregationType, allGroups: EAggregationType[]) => {
+    this.aggSwitcherCol.on(AggSwitcherColumn.EVENT_GROUP_AGG_CHANGED, async (evt: any, index: number, value: EAggregationType, allGroups: EAggregationType[]) => {
       this.updateRangeList(this.brushedItems);
-      this.stratifyColumns();
+      await this.stratifyColumns();
       this.relayout();
     });
   }
@@ -251,10 +251,7 @@ export default class ColumnManager extends EventHandler {
       if (col instanceof NumberColumn) {
         (<NumberColumn>col).updateAxis(this.brushedItems);
       }
-
     }
-    ;
-
   }
 
   async updateRangeList(brushedIndices: number[][]) {
@@ -297,7 +294,6 @@ export default class ColumnManager extends EventHandler {
    */
   mapFiltersAndSort(filterList: AnyFilter[]) {
     this.filtersHierarchy = filterList.map((d) => this.columns.filter((c) => c.data === d.data)[0]);
-    this.updateColumns();
   }
 
   /**
@@ -504,7 +500,7 @@ export default class ColumnManager extends EventHandler {
     await resolveIn(10);
     this.relayoutColStrats();
     // this.findGroupId();
-    this.correctGapBetwnMultiform();
+    this.correctGapBetweenMultiform();
     const header = 47;//TODO solve programatically
     const height = Math.min(...this.columns.map((c) => c.$node.property('clientHeight') - header));
     const rowHeight = await this.calColHeight(height);
@@ -604,7 +600,7 @@ export default class ColumnManager extends EventHandler {
     //set the propper aggregation level
     for (let i = 0; i < VisManager.modePerGroup.length; i++) {
       if (VisManager.modePerGroup[i] === EAggregationType.AUTOMATIC) {
-        const mode = aggregationNeeded && !this.checkIfGruopBrushed(i) ? EAggregationType.AGGREGATED : EAggregationType.UNAGGREGATED;
+        const mode = aggregationNeeded && !this.checkIfGroupBrushed(i) ? EAggregationType.AGGREGATED : EAggregationType.UNAGGREGATED;
         this.updateAggregationLevelForRow(i, mode);
       } else {
         this.updateAggregationLevelForRow(i, VisManager.modePerGroup[i]);
@@ -651,7 +647,7 @@ export default class ColumnManager extends EventHandler {
           minSize.push(m[ind]);
         });
         let min = Math.max(...minSize);
-        if (VisManager.modePerGroup[i] === EAggregationType.AGGREGATED || (VisManager.modePerGroup[i] === EAggregationType.AUTOMATIC && aggregationNeeded && !this.checkIfGruopBrushed(i))) {
+        if (VisManager.modePerGroup[i] === EAggregationType.AGGREGATED || (VisManager.modePerGroup[i] === EAggregationType.AUTOMATIC && aggregationNeeded && !this.checkIfGroupBrushed(i))) {
           min = 72;
           totalAggreg = totalAggreg + min;
         } else if (brushedMultiforms.indexOf(ind) !== -1) {
@@ -662,7 +658,7 @@ export default class ColumnManager extends EventHandler {
         });
         let maxBrush = 0;
         maxHeights.forEach((m) => {
-          if (VisManager.modePerGroup[i] === EAggregationType.AGGREGATED || (VisManager.modePerGroup[i] === EAggregationType.AUTOMATIC && aggregationNeeded && !this.checkIfGruopBrushed(i))) {
+          if (VisManager.modePerGroup[i] === EAggregationType.AGGREGATED || (VisManager.modePerGroup[i] === EAggregationType.AUTOMATIC && aggregationNeeded && !this.checkIfGroupBrushed(i))) {
             m[ind] = min;
           } else if (brushedMultiforms.indexOf(ind) !== -1) {
             maxBrush = m[ind];
@@ -708,7 +704,7 @@ export default class ColumnManager extends EventHandler {
     return brushedMultiforms;
   }
 
-  private checkIfGruopBrushed(rowIndex: number) {
+  private checkIfGroupBrushed(rowIndex: number) {
     let isBrushed = false;
     this.columns.forEach((col) => {
       this.multiformsInGroup(rowIndex).forEach((m) => {
@@ -721,16 +717,15 @@ export default class ColumnManager extends EventHandler {
 
   private updateAggregationLevelForRow(rowIndex: number, aggregationType: EAggregationType) {
     this.aggSwitcherCol.setAggregationType(rowIndex, aggregationType);
-
     this.columns.forEach((col) => {
-      this.multiformsInGroup(rowIndex).forEach((m) => {
-        VisManager.multiformAggregationType.set(col.multiformList[m].id, aggregationType);
+      this.multiformsInGroup(rowIndex).forEach((i) => {
+        VisManager.multiformAggregationType.set(col.multiformList[i].id, aggregationType);
       });
     });
   }
 
 
-  private correctGapBetwnMultiform() {
+  private correctGapBetweenMultiform() {
     this.columns.forEach((col, i) => {
       col.multiformList.forEach((multiform, index) => {
         if (index + 1 < col.multiformList.length) {

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -294,6 +294,7 @@ export default class ColumnManager extends EventHandler {
    */
   mapFiltersAndSort(filterList: AnyFilter[]) {
     this.filtersHierarchy = filterList.map((d) => this.columns.filter((c) => c.data === d.data)[0]);
+    this.updateColumns();
   }
 
   /**


### PR DESCRIPTION
Should solve #281, but does only half the trick. D3 data join reuses multiform groups that haven't changed. However, the flickering still remains, because of the `ColumnManager.relayout()`.

You can see that the upper group is untouched and only the bottom one is flickering on brushing.

![taggle_d3-data-join](https://cloud.githubusercontent.com/assets/5851088/24803619/09faf668-1bac-11e7-998e-388a8aadc22c.gif)

Setting a breakpoint  at `scaleTo` in `ColumnManager.relayout()` shows the problem: 

![taggle_still-flickering](https://cloud.githubusercontent.com/assets/5851088/24803694/4c8769da-1bac-11e7-8bf2-924cf904c707.gif)

The problem is that the new multiform might (or in case of brushes) will have a different height than the old/removed multiform. The "magic box" makes it even harder to set the multiform height already on creation.

At the moment I have no further idea how to prevent/solve the flickering problem.