### PR TITLE
Features/stringcolumn by default as first

### DIFF
--- a/src/SupportView.ts
+++ b/src/SupportView.ts
@@ -85,7 +85,19 @@ export default class SupportView extends EventHandler {
     this.setupFilterManager();
     await this.loadDatasets();
     this.buildSelect2(this.$node);
+    // add default column here
+    this.addDefaultColumn();
     await this.addInitialFilters();
+  }
+
+  private addDefaultColumn() {
+    // render the ID column
+    // find string column
+    console.log(this.datasets);
+    const stringColumn = this.datasets.find((x) => x.desc.value.type === VALUE_TYPE_STRING);
+    if('undefined' !== typeof stringColumn) {
+      this.addFilter(stringColumn);
+    }
   }
 
   private async loadDatasets() {

--- a/src/SupportView.ts
+++ b/src/SupportView.ts
@@ -24,6 +24,8 @@ import {formatAttributeName, formatIdTypeName} from './column/utils';
 import {IStratification} from 'phovea_core/src/stratification';
 import AFilter from './filter/AFilter';
 import {AVectorFilter} from './filter/AVectorFilter';
+import TableVector from '../../phovea_core/src/table/internal/TableVector';
+import Vector from '../../phovea_core/src/vector/Vector';
 
 
 export interface IFuelBarDataSize {
@@ -91,11 +93,15 @@ export default class SupportView extends EventHandler {
   }
 
   private addDefaultColumn() {
-    // render the ID column
-    // find string column
-    console.log(this.datasets);
-    const stringColumn = this.datasets.find((x) => x.desc.value.type === VALUE_TYPE_STRING);
+    const stringColumn = this.datasets.find((x) => (x instanceof TableVector || x instanceof Vector) && x.desc.value.type === VALUE_TYPE_STRING);
     if('undefined' !== typeof stringColumn) {
+      if (hash.has(this.idTypeHash)) { // check if we have already added a string column
+        const attributes = hash.getProp(this.idTypeHash);
+        const attributeArray = attributes.split(SupportView.HASH_FILTER_DELIMITER);
+        if(attributeArray.indexOf(stringColumn.desc.name) > -1) {
+           return; // if a string column is already present, don't add another one
+        }
+      }
       this.addFilter(stringColumn);
     }
   }

--- a/src/SupportView.ts
+++ b/src/SupportView.ts
@@ -94,16 +94,25 @@ export default class SupportView extends EventHandler {
 
   private addDefaultColumn() {
     const stringColumn = this.datasets.find((x) => (x instanceof TableVector || x instanceof Vector) && x.desc.value.type === VALUE_TYPE_STRING);
-    if('undefined' !== typeof stringColumn) {
-      if (hash.has(this.idTypeHash)) { // check if we have already added a string column
-        const attributes = hash.getProp(this.idTypeHash);
-        const attributeArray = attributes.split(SupportView.HASH_FILTER_DELIMITER);
-        if(attributeArray.indexOf(stringColumn.desc.name) > -1) {
-           return; // if a string column is already present, don't add another one
-        }
-      }
-      this.addFilter(stringColumn);
+
+    // string column available?
+    if(!stringColumn) {
+      console.error(`No string column for idType '${this.idType.name}' found!`);
+      return;
     }
+
+    // check if we have already added a string column
+    if (hash.has(this.idTypeHash)) {
+      const attributeArray = hash
+        .getProp(this.idTypeHash)
+        .split(SupportView.HASH_FILTER_DELIMITER);
+
+      if(attributeArray.indexOf(stringColumn.desc.name) > -1) {
+         return; // if a string column is already present, don't add another one
+      }
+    }
+
+    this.addFilter(stringColumn);
   }
 
   private async loadDatasets() {

--- a/src/SupportView.ts
+++ b/src/SupportView.ts
@@ -24,8 +24,8 @@ import {formatAttributeName, formatIdTypeName} from './column/utils';
 import {IStratification} from 'phovea_core/src/stratification';
 import AFilter from './filter/AFilter';
 import {AVectorFilter} from './filter/AVectorFilter';
-import TableVector from '../../phovea_core/src/table/internal/TableVector';
-import Vector from '../../phovea_core/src/vector/Vector';
+import TableVector from 'phovea_core/src/table/internal/TableVector';
+import Vector from 'phovea_core/src/vector/Vector';
 
 
 export interface IFuelBarDataSize {


### PR DESCRIPTION
When opening a dataset, the string column will be shown as default.

![aaa](https://cloud.githubusercontent.com/assets/3988444/25795792/3e34867c-33d7-11e7-986f-e604f40359a1.png)

Related issue: https://github.com/Caleydo/taggle/issues/333