### PR TITLE
Adjustable column width (#106)

### DIFF
--- a/src/column/AColumn.ts
+++ b/src/column/AColumn.ts
@@ -167,7 +167,6 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
    */
   protected buildResizable($handle: d3.Selection<any>) {
     const drag = d3.behavior.drag()
-      //.on('dragstart', () => console.log('start', d3.event))
       .on('drag', () => {
         const width = (<any>d3.event).x;
         // respect the given min-width
@@ -191,7 +190,7 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
 
     this.width = width;
 
-    // set lockWidth to avoid overiding the width from ColumnManager.distributeColWidths()
+    // set lockWidth to avoid overriding the width by ColumnManager.distributeColWidths()
     this.lockedWidth = this.width;
 
     this.$node.select('.lock-column')

--- a/src/column/AColumn.ts
+++ b/src/column/AColumn.ts
@@ -8,7 +8,7 @@ import {EventHandler} from 'phovea_core/src/event';
 import * as d3 from 'd3';
 import {SORT} from '../SortHandler/SortHandler';
 import {createNode} from 'phovea_core/src/multiform/internal';
-import {formatAttributeName} from './utils';
+import {formatAttributeName, scaleTo} from './utils';
 import {IVisPluginDesc, list as listVisses} from 'phovea_core/src/vis';
 import VisManager from './VisManager';
 import {EAggregationType} from './VisManager';
@@ -45,10 +45,21 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
   selectedUnaggVis: IVisPluginDesc;
   matrixFilters: AnyFilter[];//For the header in matrix
 
+  private _width:number = 0;
+
   protected multiformMap: Map<string, TaggleMultiform> = new Map<string, TaggleMultiform>();
 
   constructor(public readonly data: DATATYPE, public readonly orientation: EOrientation) {
     super();
+  }
+
+  set width(value:number) {
+    this._width = value;
+    this.$node.style('width', value + 'px');
+  }
+
+  get width():number {
+    return this._width;
   }
 
   get multiformList():TaggleMultiform[] {
@@ -116,6 +127,7 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
       .html(`
         <aside></aside>
         <header class="columnHeader">
+          <div class="resize-handle"></div>
           <div class="toolbar">
             <div class="labelName" title="${formatAttributeName(this.data.desc.name)}"><i class="${dataValueTypeCSSClass(dataValueType(this.data))}" aria-hidden="true"></i> <span>${formatAttributeName(this.data.desc.name)}</span></div>
             <div class="onHoverToolbar"></div>
@@ -123,7 +135,9 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
         </header>
         <main></main>`);
 
+    this.buildResizable($node.select('div.resize-handle'));
     this.buildToolbar($node.select('div.toolbar'));
+
     $node.select('div.onHoverToolbar')
       .style('display', 'none' )
       .style('visibility', 'hidden');
@@ -143,9 +157,49 @@ abstract class AColumn<T, DATATYPE extends IDataType> extends EventHandler {
     return $node;
   }
 
+  /**
+   * Add a drag behavior to a given node
+   * @param $handle
+   */
+  protected buildResizable($handle: d3.Selection<any>) {
+    const drag = d3.behavior.drag()
+      //.on('dragstart', () => console.log('start', d3.event))
+      .on('drag', this.resizableDragBehavior.bind(this));
+      //.on('dragend', () => console.log('start', d3.event))
+
+    $handle.call(drag);
+  }
+
+  /**
+   * Simple resize behavior for the column width by scaling each multiform within the column
+   */
+  protected resizableDragBehavior() {
+    const width = (<any>d3.event).x;
+
+    // respect the given min-width
+    if(width <= this.minWidth) {
+      return;
+    }
+
+    this.width = width;
+
+    // set lockWidth to avoid overiding the width from ColumnManager.distributeColWidths()
+    this.lockedWidth = this.width;
+
+    this.$node.select('.lock-column')
+        .classed('active', true)
+        .attr('title', 'Unlock column')
+        .html(`<i class="fa fa-lock fa-fw" aria-hidden="true"></i><span class="sr-only">Unlock column</span>`);
+
+    this.multiformList.forEach((multiform) => {
+      scaleTo(multiform, this.width, multiform.size[1], this.orientation);
+    });
+  }
+
   protected buildToolbar($toolbar: d3.Selection<any>) {
     const $hoverToolbar =  $toolbar.select('div.onHoverToolbar');
     const $lockButton = $hoverToolbar.append('a')
+      .classed('lock-column', true)
       .attr('title', 'Lock column')
       .html(`<i class="fa fa-unlock fa-fw" aria-hidden="true"></i><span class="sr-only">Lock column</span>`)
       .on('click', () => {

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -567,7 +567,7 @@ export default class ColumnManager extends EventHandler {
     }
 
     this.columns.forEach((col, i) => {
-      col.$node.style('width', colWidths[i] + 'px');
+      col.width = colWidths[i];
       col.multiformList.forEach((multiform, index) => {
         this.visManager.assignVis(multiform);
         scaleTo(multiform, colWidths[i], rowHeight[index], col.orientation);

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -47,16 +47,18 @@ import {AGGREGATE} from './MatrixColumn';
 import SupportView from '../SupportView';
 import RowNumberColumn from './RowNumberColumn';
 import Any = jasmine.Any;
+import {hash} from 'phovea_core/src/index';
 
 export declare type AnyColumn = AColumn<any, IDataType>;
 export declare type IMotherTableType = IStringVector | ICategoricalVector | INumericalVector | INumericalMatrix;
 
 export default class ColumnManager extends EventHandler {
 
-
   static readonly EVENT_COLUMN_REMOVED = 'columnRemoved';
   static readonly EVENT_COLUMN_ADDED = 'columnAdded';
   static readonly EVENT_DATA_REMOVED = 'removedData';
+
+  private static readonly HASH_FILTER_DELIMITER = ',';
 
   private $node: d3.Selection<any>;
 
@@ -86,6 +88,7 @@ export default class ColumnManager extends EventHandler {
   private onVisChange = (event: IEvent) => this.relayout();
   private onMatrixToVector = (event: IEvent, data: IDataType, aggfunction, col) => this.fire(MatrixColumn.EVENT_CONVERT_TO_VECTOR, data, aggfunction, col);
   private onVectorToMatrix = (event: IEvent, data: IDataType) => this.fire(NumberColumn.EVENT_CONVERT_TO_MATRIX, data);
+  private onWidthChanged = (event:IEvent) => this.setWidthToURLHash();
   private stratifyMe = (event: IEvent, colid) => {
     this.stratifyColId = colid.data.desc.id;
     this.stratifyAndRelayout();
@@ -149,6 +152,24 @@ export default class ColumnManager extends EventHandler {
     this.$parent.selectAll('.column').remove();
   }
 
+  private setWidthToURLHash() {
+    hash.setProp('colWidths',
+      this.filtersHierarchy
+        .map((d) => d.width.toFixed())
+        .join(ColumnManager.HASH_FILTER_DELIMITER)
+    );
+  }
+
+  private initWidthFromURLHash(column:AColumn<any,any>) {
+    if (hash.has('colWidths')) {
+      const widths = hash.getProp('colWidths')
+        .split(ColumnManager.HASH_FILTER_DELIMITER);
+
+      const width = parseFloat(widths[this.columns.indexOf(column)]);
+      column.setFixedWidth(width);
+    }
+  }
+
   /**
    * Adding a new column from given data
    * Called when adding a new filter from dropdown or from hash
@@ -169,8 +190,11 @@ export default class ColumnManager extends EventHandler {
     col.on(AVectorFilter.EVENT_SORTBY_FILTER_ICON, this.onSortByFilterHeader);
     col.on(MatrixColumn.EVENT_CONVERT_TO_VECTOR, this.onMatrixToVector);
     col.on(NumberColumn.EVENT_CONVERT_TO_MATRIX, this.onVectorToMatrix);
+    col.on(AColumn.EVENT_WIDTH_CHANGED, this.onWidthChanged);
 
     this.columns.push(col);
+
+    this.initWidthFromURLHash(col);
 
     // add column to hierarchy if it isn't a matrix and already added
     const id = this.filtersHierarchy.filter((c) => c.data.desc.id === col.data.desc.id);
@@ -573,6 +597,8 @@ export default class ColumnManager extends EventHandler {
         scaleTo(multiform, colWidths[i], rowHeight[index], col.orientation);
       });
     });
+
+    this.setWidthToURLHash();
   }
 
   private multiformsInGroup(groupIndex: number) {

--- a/src/column/ColumnManager.ts
+++ b/src/column/ColumnManager.ts
@@ -160,12 +160,12 @@ export default class ColumnManager extends EventHandler {
     );
   }
 
-  private initWidthFromURLHash(column:AColumn<any,any>) {
+  private initWidthFromURLHash(column:AnyColumn) {
     if (hash.has('colWidths')) {
       const widths = hash.getProp('colWidths')
         .split(ColumnManager.HASH_FILTER_DELIMITER);
 
-      const width = parseFloat(widths[this.columns.indexOf(column)]);
+      const width = parseFloat(widths[this.filtersHierarchy.indexOf(column)]);
       column.setFixedWidth(width);
     }
   }
@@ -194,13 +194,13 @@ export default class ColumnManager extends EventHandler {
 
     this.columns.push(col);
 
-    this.initWidthFromURLHash(col);
-
     // add column to hierarchy if it isn't a matrix and already added
     const id = this.filtersHierarchy.filter((c) => c.data.desc.id === col.data.desc.id);
     if (col.data.desc.type !== AColumn.DATATYPE.matrix && id.length === 0) {
       this.filtersHierarchy.push(col);
     }
+
+    this.initWidthFromURLHash(col);
 
     this.fire(ColumnManager.EVENT_COLUMN_ADDED, col);
 

--- a/src/column/MatrixColumn.ts
+++ b/src/column/MatrixColumn.ts
@@ -67,13 +67,8 @@ export default class MatrixColumn extends AColumn<number, INumericalMatrix> {
     return $node;
   }
 
-  protected resizableDragBehavior() {
-    super.resizableDragBehavior();
-
-    const width = (<any>d3.event).x;
-
-    // respect the given min-width
-    if(width <= this.minWidth) {
+  setFixedWidth(width:number) {
+    if(isNaN(width)) {
       return;
     }
 
@@ -84,6 +79,8 @@ export default class MatrixColumn extends AColumn<number, INumericalMatrix> {
         scaleTo(multiform, width, multiform.size[1], col.orientation);
       });
     });
+
+    super.setFixedWidth(width);
   }
 
   protected multiFormParams($body: d3.Selection<any>): IMultiFormOptions {

--- a/src/column/MatrixColumn.ts
+++ b/src/column/MatrixColumn.ts
@@ -67,6 +67,25 @@ export default class MatrixColumn extends AColumn<number, INumericalMatrix> {
     return $node;
   }
 
+  protected resizableDragBehavior() {
+    super.resizableDragBehavior();
+
+    const width = (<any>d3.event).x;
+
+    // respect the given min-width
+    if(width <= this.minWidth) {
+      return;
+    }
+
+    // scale all column stratifications
+    this.colStratManager.columns.forEach((col) => {
+      col.width = width;
+      col.multiformList.forEach((multiform) => {
+        scaleTo(multiform, width, multiform.size[1], col.orientation);
+      });
+    });
+  }
+
   protected multiFormParams($body: d3.Selection<any>): IMultiFormOptions {
     return {
       initialVis: VisManager.getDefaultVis(this.data.desc.type, this.data.desc.value.type, EAggregationType.UNAGGREGATED),

--- a/src/column/NumberColumn.ts
+++ b/src/column/NumberColumn.ts
@@ -98,8 +98,11 @@ export default class NumberColumn extends AVectorColumn<number, INumericalVector
     this.$axis.call(this.axis);
   }
 
-  protected resizableDragBehavior() {
-    super.resizableDragBehavior();
+  setFixedWidth(width:number) {
+    if(isNaN(width)) {
+      return;
+    }
+    super.setFixedWidth(width);
     this.updateAxisScale();
   }
 

--- a/src/column/NumberColumn.ts
+++ b/src/column/NumberColumn.ts
@@ -22,7 +22,10 @@ export default class NumberColumn extends AVectorColumn<number, INumericalVector
   matrixViewRange: Range;
 
   private $points:d3.Selection<any>;
-  private scale: d3.scale.Linear<number, number>;
+  private $axis:d3.Selection<any>;
+  private scale: d3.scale.Linear<number, number> = d3.scale.linear();
+  private axis: d3.svg.Axis = d3.svg.axis();
+
   public static EVENT_CONVERT_TO_MATRIX = 'convertToMatrix';
 
   constructor(data: INumericalVector, orientation: EOrientation, $parent: d3.Selection<any>, matrixCol?: MatrixColumn) {
@@ -33,22 +36,31 @@ export default class NumberColumn extends AVectorColumn<number, INumericalVector
 
   protected buildToolbar($toolbar: d3.Selection<any>) {
     super.buildToolbar($toolbar);
-    this.$points = $toolbar.select('svg').append('g');
-    const $svg = $toolbar.select('svg').append('g');
-    const width =$toolbar.node().parentElement.getBoundingClientRect().width;
+    this.buildAxis($toolbar);
+  }
 
-    this.scale = d3.scale.linear().range([0, width]).domain((this.data.desc).value.range);
+  private buildAxis($toolbar: d3.Selection<any>) {
+    this.$points = $toolbar.select('svg').append('g').classed('points', true);
+    this.$axis = $toolbar.select('svg').append('g').classed('axis', true);
+    const width = $toolbar.node().parentElement.getBoundingClientRect().width;
+
+    this.scale
+      .range([0, width])
+      .domain((this.data.desc).value.range);
+
     const tickCount = 0;
-    const axis = d3.svg.axis()
+    this.axis
       .ticks(tickCount)
       .tickFormat(d3.format('.2s'))
       .outerTickSize(8)
       .orient('bottom')
-      .scale(this.scale);
-    axis.tickValues(this.scale.ticks(tickCount).concat( this.scale.domain()));
-    $svg.call(axis);
-    const count = $svg.selectAll('.tick').size();
-    $svg.selectAll('.tick').each(function(data, i) {
+      .scale(this.scale)
+      .tickValues(this.scale.ticks(tickCount).concat(this.scale.domain()));
+
+    this.$axis.call(this.axis);
+
+    const count = this.$axis.selectAll('.tick').size();
+    this.$axis.selectAll('.tick').each(function(data, i) {
       if(i === count-1) {
         const tick = d3.select(this).select('text');
         tick.style('text-anchor', 'end');
@@ -81,6 +93,15 @@ export default class NumberColumn extends AVectorColumn<number, INumericalVector
     });
   }
 
+  private updateAxisScale() {
+    this.scale.range([0, this.width]);
+    this.$axis.call(this.axis);
+  }
+
+  protected resizableDragBehavior() {
+    super.resizableDragBehavior();
+    this.updateAxisScale();
+  }
 
   protected multiFormParams($body: d3.Selection<any>, histogramData?: ITaggleHistogramData): IMultiFormOptions {
     return mixin(super.multiFormParams($body), {

--- a/src/styles/_columnManager.scss
+++ b/src/styles/_columnManager.scss
@@ -138,6 +138,27 @@
         margin-top: 2px;
       }
 
+      .resize-handle {
+        display: block;
+        width: 5px;
+        background: $toolbar-link-color;
+        position: absolute;
+        right: -2px;
+        top: 0;
+        bottom: 0;
+        cursor: ew-resize;
+        visibility: hidden;
+        opacity: 0;
+        transition: opacity .3s ease-in-out;
+      }
+
+      &:hover {
+        .resize-handle {
+          visibility: visible;
+          opacity: 1;
+        }
+      }
+
     }
 
     main {


### PR DESCRIPTION
Closes #106

![ea5eaf97-19f2-4142-8b94-3ff09f25bac8](https://cloud.githubusercontent.com/assets/5851088/26833688/77508010-4ad3-11e7-8ae7-d6f75c416bd3.gif)

Note: The width is stored based on the filter hierarchy, i.e. (as before) multiple columns of the same attribute won't be restored.