### PR TITLE
Removed matrix filter

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -310,8 +310,6 @@ export default class App {
     return supportView.init()
       .then(() => {
         this.supportView.push(supportView);
-        const matrix = this.supportView[0].getMatrixData(col.data.desc.id);
-        new MatrixFilter(matrix.t, supportView.$node);
         supportView.on(AVectorFilter.EVENT_SORTBY_FILTER_ICON, (evt: any, data) => {
           col.sortByFilterHeader(data);
         });


### PR DESCRIPTION
Fixes https://github.com/Caleydo/taggle/issues/393

If a new matrix is added, the matrix filter in the  SupportView won't be rendered from now on.

![image](https://user-images.githubusercontent.com/3988444/27544405-55cba2c0-5a8d-11e7-8641-f2c71eff5a1e.png)
